### PR TITLE
F/mongodb uri skeleton 3.8

### DIFF
--- a/en/syslog-ng-guide-admin/chapters/destination-mongodb.xml
+++ b/en/syslog-ng-guide-admin/chapters/destination-mongodb.xml
@@ -143,7 +143,7 @@
             </warning>
         </simplesect>
         <simplesect xml:id="mongodb-option-database">
-            <title>database()</title>
+            <title>database() (DEPRECATED)</title>
             <indexterm type="parameter">
                 <primary>database()</primary>
             </indexterm>
@@ -186,7 +186,7 @@
             <xi:include href="../../common/chunk/option-destination-on-error.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
         </simplesect>
         <simplesect xml:id="mongodb-option-password">
-            <title>password()</title>
+            <title>password() (DEPRECATED)</title>
             <indexterm type="parameter">
                 <primary>password()</primary>
             </indexterm>
@@ -212,7 +212,7 @@
             <para><emphasis role="bold">Description:</emphasis> Password of the database user.</para>
         </simplesect>
         <simplesect xml:id="mongodb-option-path">
-            <title>path()</title>
+            <title>path() (DEPRECATED)</title>
             <indexterm type="parameter">
                 <primary>path()</primary>
             </indexterm>
@@ -244,7 +244,7 @@
             <para>For MongoDB operations, &abbrev; uses a one-minute timeout: if an operation times out, &abbrev; assumes the operation has failed.</para>
         </simplesect>
         <simplesect xml:id="mongodb-option-safe-mode">
-            <title>safe-mode()</title>
+            <title>safe-mode() (DEPRECATED)</title>
             <indexterm type="parameter">
                 <primary>safe-mode()</primary>
             </indexterm>
@@ -275,7 +275,7 @@
             <para><emphasis role="bold">Description:</emphasis> If <parameter>safe-mode()</parameter> is enabled, &abbrev; performs an extra check after each insert to verify that the insert succeeded. The insert is successful only if this second check is successful. Note that enabling this option reduces the performance of the driver.</para>
         </simplesect>
         <simplesect xml:id="mongodb-option-servers">
-            <title>servers()</title>
+            <title>servers() (DEPRECATED)</title>
             <indexterm type="parameter">
                 <primary>servers()</primary>
             </indexterm>
@@ -309,7 +309,7 @@
             <xi:include href="../../common/chunk/option-destination-throttle.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
         </simplesect>
         <simplesect xml:id="mongodb-option-username">
-            <title>username()</title>
+            <title>username() (DEPRECATED)</title>
             <indexterm type="parameter">
                 <primary>username()</primary>
             </indexterm>

--- a/en/syslog-ng-guide-admin/chapters/destination-mongodb.xml
+++ b/en/syslog-ng-guide-admin/chapters/destination-mongodb.xml
@@ -318,6 +318,32 @@
         <simplesect>
             <xi:include href="../../common/chunk/option-destination-throttle.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
         </simplesect>
+        <simplesect xml:id="mongodb-option-uri">
+            <title>uri()</title>
+            <indexterm type="parameter">
+                <primary>uri()</primary>
+            </indexterm>
+            <informaltable frame="topbot" colsep="0" rowsep="0">
+                <tgroup cols="2">
+                    <colspec colnum="1" colwidth="40pt"/>
+                    <tbody>
+                        <row>
+                            <entry>Type: <?dbhtml bgcolor="#D4D6EB" ?>
+<?dbfo bgcolor="#D4D6EB" ?>
+                            </entry>
+                            <entry>string</entry>
+                        </row>
+                        <row>
+                            <entry>Default: <?dbhtml bgcolor="#D4D6EB" ?>
+<?dbfo bgcolor="#D4D6EB" ?>
+                            </entry>
+                            <entry>mongodb://127.0.0.1:27017/syslog?wtimeoutMS=60000&socketTimeoutMS=60000&connectTimeoutMS=60000</entry>
+                        </row>
+                    </tbody>
+                </tgroup>
+            </informaltable>
+            <para><emphasis role="bold">Description:</emphasis> Available in syslog-ng OSE 3.8 and later. Please refer to the <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://docs.mongodb.org/manual/reference/connection-string/">MongoDB URI format documentation</link> for detailed syntax.</para>
+        </simplesect>
         <simplesect xml:id="mongodb-option-username">
             <title>username() (DEPRECATED)</title>
             <indexterm type="parameter">

--- a/en/syslog-ng-guide-admin/chapters/destination-mongodb.xml
+++ b/en/syslog-ng-guide-admin/chapters/destination-mongodb.xml
@@ -27,6 +27,16 @@
         <para>The following example displays the default values, and is equivalent with the previous example.</para>
         <synopsis>destination d_mongodb {
     mongodb(
+        uri("mongodb://localhost:27017/syslog")
+        collection("messages")
+        value-pairs(
+            scope("selected-macros" "nv-pairs" "sdata")
+        )
+    );
+};</synopsis>
+        <para>The following example shows the same setup using the deprecated libmongo-client syntax, and is equivalent with the previous example.</para>
+        <synopsis>destination d_mongodb {
+    mongodb(
         servers("localhost:27017")
         database("syslog")
         collection("messages")


### PR DESCRIPTION
First mentions of mongodb uri() syntax, preparing for OSE 3.8. Probably shouldn't merge right now, but I'm open to comments.