### PR TITLE
Fix python documentation

### DIFF
--- a/en/syslog-ng-guide-admin/chapters/reference-template-functions.xml
+++ b/en/syslog-ng-guide-admin/chapters/reference-template-functions.xml
@@ -411,9 +411,9 @@
             <para/>
         </formalpara>
         <synopsis>python {
-    def &lt;name_of_the_python_function&gt;(&lt;log_message&gt;, &lt;optional_other_arguments&gt;):
-        # &lt;your-python-code&gt;
-        return &lt;value_of_the_template_function&gt;
+def &lt;name_of_the_python_function&gt;(&lt;log_message&gt;, &lt;optional_other_arguments&gt;):
+    # &lt;your-python-code&gt;
+    return &lt;value_of_the_template_function&gt;
 };
 
 template &lt;template-name&gt; {
@@ -425,8 +425,8 @@ template &lt;template-name&gt; {
             <synopsis>@version: &techversion;
 
 python {
-    def return_message(log_message):
-        return log_message.MESSAGE
+def return_message(log_message):
+    return log_message.MESSAGE
 };
 
 destination d_local {
@@ -436,13 +436,13 @@ destination d_local {
             <synopsis>@version: &techversion;
 
 python {
-    import socket
+import socket
 
-    def resolve_host(log_message, hostname):
-        try:
-            return socket.gethostbyaddr(hostname)[0]
-        except (socket.herror, socket.error):
-            return 'unknown'
+def resolve_host(log_message, hostname):
+    try:
+        return socket.gethostbyaddr(hostname)[0]
+    except (socket.herror, socket.error):
+        return 'unknown'
 };
 
 destination d_local {


### PR DESCRIPTION
In python, whitespace at the left of instructions has a meaning, and
therefore shouldn't be used for padding. This commit fixes the python
blocks in the documentation, as the didn't work as-is before.