### PR TITLE
[ose3.13][admin] TLS Client: Correct typo in step number

### DIFF
--- a/en/syslog-ng-guide-admin/chapters/chapter-encrypted-transport-tls.xml
+++ b/en/syslog-ng-guide-admin/chapters/chapter-encrypted-transport-tls.xml
@@ -97,7 +97,7 @@
                 </example>
             </step>
             <step>
-                <para>Include the destination created in Step 2 in a log statement.</para>
+                <para>Include the destination created in Step 4 in a log statement.</para>
                 <warning>
                     <para>The encrypted connection between the server and the client fails if the <parameter>Common Name</parameter> or the <parameter>subject_alt_name</parameter> parameter of the server certificate does not contain the hostname or the IP address (as resolved from the syslog-ng clients and relays) of the server.</para>
                     <para>Do not forget to update the certificate files when they expire.</para>


### PR DESCRIPTION
This PR fixes a typo where the wrong paragraph is referenced.