### PR TITLE
[ose]: Example 8.12 typo fix

### DIFF
--- a/en/syslog-ng-guide-admin/chapters/chapter-routing-filters.xml
+++ b/en/syslog-ng-guide-admin/chapters/chapter-routing-filters.xml
@@ -610,7 +610,7 @@ log {
                 <synopsis>filter f_pid {"${PID}" !=""};</synopsis>
                 <para>The following expression selects log messages that do not contain a PID. Also, it uses a template as the left argument of the operator and compares the values as strings:</para>
                 <synopsis>filter f_pid {"${HOST}${PID}" eq "${HOST}"};</synopsis>
-                <para>The following example selects messages with priority level 4 or higher.</para>
+                <para>The following example selects messages with priority level higher than 5.</para>
                 <synopsis>filter f_level {"${LEVEL_NUM}" &gt; "5"};</synopsis>
             </example>
             <para>Note that:</para>


### PR DESCRIPTION
In the example 8.12, the expression is `filter f_level {"${LEVEL_NUM}" > "5"};` but the explanation given is **The following example selects messages with priority level 4 or higher.**. The correct one should be **The following example selects messages with priority level higher than 5.**