### PR TITLE
Document the %f field of the date parser

### DIFF
--- a/en/syslog-ng-guide-admin/chapters/parser-date.xml
+++ b/en/syslog-ng-guide-admin/chapters/parser-date.xml
@@ -89,6 +89,7 @@ log {
 %C      ctime format: Sat Nov 19 21:05:57 1994
 %d      numeric day of the month, with leading zeros (eg 01..31)
 %e      like %d, but a leading zero is replaced by a space (eg  1..31)
+%f      microseconds, leading 0's, extra digits are silently discarded
 %D      MM/DD/YY
 %G      GPS week number (weeks since January 6, 1980)
 %h      month, abbreviated


### PR DESCRIPTION
Support for a `%f` field was added in balabit/syslog-ng#2709