### PR TITLE
[ose][admin] remove mongodb() related compile option

### DIFF
--- a/en/syslog-ng-guide-admin/chapters/compiling-syslog-ng-options.xml
+++ b/en/syslog-ng-guide-admin/chapters/compiling-syslog-ng-options.xml
@@ -58,7 +58,7 @@
         <listitem>
             <indexterm> <primary>destinations</primary> <secondary>mongodb()</secondary> </indexterm>
             <indexterm> <primary>mongodb()</primary> <secondary>compiling</secondary> </indexterm>
-            <para><emphasis>--enable-mongodb</emphasis> Enable the mongodb destination (enabled by default). The source of the MongoDB client is included in the source code package of &abbrev;. To use an external MongoDB client instead, use the <parameter>--with-libmongo-client=system</parameter> compiling option. For details on using this destination, see <xref linkend="configuring-destinations-mongodb"/>.</para>
+            <para><emphasis>--enable-mongodb</emphasis> Enable the mongodb destination (enabled by default). To use mongodb() an external MongoDB client is needed. For details on using this destination, see <xref linkend="configuring-destinations-mongodb"/>.</para>
         </listitem>
         <listitem>
             <indexterm> <primary>sources</primary> <secondary>pacct()</secondary> </indexterm>
@@ -118,11 +118,6 @@
             <indexterm> <primary>destinations</primary> <secondary>redis()</secondary> </indexterm>
             <indexterm> <primary>redis()</primary> <secondary>compiling</secondary> </indexterm>
             <para><emphasis>--with-libhiredis</emphasis> Specifies the path to the libhiredis library (0.11 or newer). For details on using this destination, see <xref linkend="configuring-destinations-redis"/>.</para>
-        </listitem>
-        <listitem>
-            <indexterm> <primary>destinations</primary> <secondary>mongodb()</secondary> </indexterm>
-            <indexterm> <primary>mongodb()</primary> <secondary>compiling</secondary> </indexterm>
-            <para><emphasis>--with-libmongo-client</emphasis> Specifies which MongoDB client to use (default value: internal). The source of the mongodb client is included in the source code package of &abbrev;. To use an external MongoDB client instead, use the <parameter>--with-libmongo-client=system</parameter> compiling option. For details on using this destination, see <xref linkend="configuring-destinations-mongodb"/>.</para>
         </listitem>
         <listitem>
             <indexterm> <primary>destinations</primary> <secondary>amqp()</secondary> </indexterm>


### PR DESCRIPTION
`--with-libmongo-client` had been removed

Since 3.18 OSE no longer ships mongo-c driver and the above option had been removed too.

See commit [ce447963e2fbf6f5355b7bdd46248d9263c57368](https://github.com/balabit/syslog-ng/commit/ce447963e2fbf6f5355b7bdd46248d9263c57368) in OSE repository
> afmongodb: remove mongo-c-driver submodule and its support
