### PR TITLE
ose 3.35 DOC-5396 TLS X509 macros should be lowercase

### DIFF
--- a/Content/Guides/syslog-ng-guide-admin/chapters/reference-macros.htm
+++ b/Content/Guides/syslog-ng-guide-admin/chapters/reference-macros.htm
@@ -545,29 +545,29 @@ When used, the output specifies the protocol used on the source from which the m
         <MadCap:snippetBlock src="../../shared/chunk/macro-unixtime.htm">
         </MadCap:snippetBlock>
         <div>
-            <h6 name="macro-tls-x509"><a name="macro-tls-x509"></a>.TLS.X509</h6>
-            <MadCap:keyword term=".TLS.X509_CN">
+            <h6 name="macro-tls-x509"><a name="macro-tls-x509"></a>.tls.x509</h6>
+            <MadCap:keyword term=".tls.x509_cn">
             </MadCap:keyword>
-            <MadCap:keyword term="${.TLS.X509_CN}">
+            <MadCap:keyword term="${.tls.x509_cn}">
             </MadCap:keyword>
-            <MadCap:keyword term=".TLS.X509_O">
+            <MadCap:keyword term=".tls.x509_o">
             </MadCap:keyword>
-            <MadCap:keyword term="${.TLS.X509_O}">
+            <MadCap:keyword term="${.tls.x509_o}">
             </MadCap:keyword>
-            <MadCap:keyword term=".TLS.X509_OU">
+            <MadCap:keyword term=".tls.x509_ou">
             </MadCap:keyword>
-            <MadCap:keyword term="${.TLS.X509_OU}">
+            <MadCap:keyword term="${.tls.x509_ou}">
             </MadCap:keyword>
             <p><i style="font-style: normal;">Description:</i> When using a transport that uses TLS, these macros contain information about the peer's certificate. That way, you can use information from the client certificate in filenames, database values, or as other metadata. If you clients have their own certificates, then these values are unique per client, but unchangeable by the client. The following macros are available in <MadCap:variable name="General.OSE"></MadCap:variable> version <MadCap:conditionaltext MadCap:conditions="General.pe">7</MadCap:conditionaltext><MadCap:conditionaltext MadCap:conditions="General.ose">3.9</MadCap:conditionaltext> and later.</p>
             <ul>
                 <li>
-                    <p><span class="Code" oldrole="parameter">.TLS.X509_CN</span>: The Common Name of the certificate.</p>
+                    <p><span class="Code" oldrole="parameter">.tls.x509_cn</span>: The Common Name of the certificate.</p>
                 </li>
                 <li>
-                    <p><span class="Code" oldrole="parameter">.TLS.X509_O</span>: The value of the Organization field.</p>
+                    <p><span class="Code" oldrole="parameter">.tls.x509_o</span>: The value of the Organization field.</p>
                 </li>
                 <li>
-                    <p><span class="Code" oldrole="parameter">.TLS.X509_OU</span>: The value of the Organization Unit field.</p>
+                    <p><span class="Code" oldrole="parameter">.tls.x509_ou</span>: The value of the Organization Unit field.</p>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Fixes syslog-ng/syslog-ng#3494