### PR TITLE
Proxy Protocol support

### DIFF
--- a/Content/Guides/shared/chunk/option-source-transport.htm
+++ b/Content/Guides/shared/chunk/option-source-transport.htm
@@ -13,7 +13,7 @@
                 <tr class="TableStyle-RuledTableWithHeading_DoNotEdit-Body-Body1">
                     <td class="TableStyle-RuledTableWithHeading_DoNotEdit-BodyE-Column1-Body1">Type:</td>
                     <td class="TableStyle-RuledTableWithHeading_DoNotEdit-BodyD-Column1-Body1">
-                        <MadCap:conditionaltext MadCap:conditions="General.pe">rltp, </MadCap:conditionaltext>udp, tcp, or tls</td>
+                        <MadCap:conditionaltext MadCap:conditions="General.pe">rltp, </MadCap:conditionaltext>udp, tcp, tls, proxied-tcp, or proxied-tls</td>
                 </tr>
                 <tr class="TableStyle-RuledTableWithHeading_DoNotEdit-Body-Body1">
                     <td class="TableStyle-RuledTableWithHeading_DoNotEdit-BodyB-Column1-Body1">Default:</td>
@@ -24,5 +24,6 @@
             </col>
         </table>
         <p><i style="font-style: normal;">Description:</i> Specifies the protocol used to receive messages from the source.</p>
+        <p>For detailed information about how from version 3.30 onwards, <MadCap:variable name="General.OSE" /> supports the <span class="Code">proxied-tcp</span> parameter and the <span class="Code">proxied-tls</span> parameter, see <MadCap:xref href="../../syslog-ng-guide-admin/chapters/proxy-prot-intro.htm"><span style="color: #04aada;" class="mcFormatColor">Proxy Protocol support</span></MadCap:xref>.</p>
     </body>
 </html>

--- a/Content/Guides/shared/chunk/option-source-transport.htm
+++ b/Content/Guides/shared/chunk/option-source-transport.htm
@@ -13,7 +13,7 @@
                 <tr class="TableStyle-RuledTableWithHeading_DoNotEdit-Body-Body1">
                     <td class="TableStyle-RuledTableWithHeading_DoNotEdit-BodyE-Column1-Body1">Type:</td>
                     <td class="TableStyle-RuledTableWithHeading_DoNotEdit-BodyD-Column1-Body1">
-                        <MadCap:conditionaltext MadCap:conditions="General.pe">rltp, </MadCap:conditionaltext>udp, tcp, tls, proxied-tcp, or proxied-tls</td>
+                        <MadCap:conditionaltext MadCap:conditions="General.pe">rltp, </MadCap:conditionaltext>udp, tcp, tls, proxied-tcp, proxied-tls, or proxied-tls-passthrough</td>
                 </tr>
                 <tr class="TableStyle-RuledTableWithHeading_DoNotEdit-Body-Body1">
                     <td class="TableStyle-RuledTableWithHeading_DoNotEdit-BodyB-Column1-Body1">Default:</td>
@@ -24,6 +24,6 @@
             </col>
         </table>
         <p><i style="font-style: normal;">Description:</i> Specifies the protocol used to receive messages from the source.</p>
-        <p>For detailed information about how from version 3.30 onwards, <MadCap:variable name="General.OSE" /> supports the <span class="Code">proxied-tcp</span> parameter and the <span class="Code">proxied-tls</span> parameter, see <MadCap:xref href="../../syslog-ng-guide-admin/chapters/proxy-prot-intro.htm"><span style="color: #04aada;" class="mcFormatColor">Proxy Protocol support</span></MadCap:xref>.</p>
+        <p>For detailed information about how <MadCap:variable name="General.OSE" /> supports the <span class="Code">proxied-tcp</span>, the <span class="Code">proxied-tls</span>, and the <span class="Code">proxied-tls-passthrough</span> parameters, see <MadCap:xref href="../../syslog-ng-guide-admin/chapters/proxy-prot-intro.htm"><span style="color: #04aada;" class="mcFormatColor">Proxy Protocol support</span></MadCap:xref>.</p>
     </body>
 </html>

--- a/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-conf.htm
+++ b/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-conf.htm
@@ -10,17 +10,18 @@
         <div>
             <h6>Enabling Proxy Protocol support for your network() source options</h6>
             <p>Unless you enable Proxy Protocol support for your <span class="Code">network()</span> source, <MadCap:variable name="General.OSE" /> identifies every connection that is connected to the load balancers identically by default, regardless of the source IP or the source protocol.</p>
-            <p class="Procedure">To enable Proxy Protocol for your <span class="Code">network()</span> source, set <a href="reference-source-network.htm"><span style="color: #04aada;" class="mcFormatColor">the <span class="Code">transport()</span> parameter of your <span class="Code">network()</span> source</span></a> to <span class="Code">proxied-tcp</span> or <span class="Code">proxied-tls</span>, depending on your preference and configuration.</p>
+            <p>To enable Proxy Protocol for your <span class="Code">network()</span> source, set <a href="reference-source-network.htm"><span style="color: #04aada;" class="mcFormatColor">the <span class="Code">transport()</span> parameter of your <span class="Code">network()</span> source</span></a> to <span class="Code">proxied-tcp</span> or <span class="Code">proxied-tls-passthrough</span>, depending on your preference and configuration.</p>
+            <p><span class="Code">proxied-tls</span> can be used in complex MITM (man in the middle) configurations, where the proxy header is sent encrypted within the same TLS session as the proxied messages.</p>
             <p>When you enable Proxy Protocol support  for your <span class="Code">network()</span> source, you can use the following configuration example with your <MadCap:variable name="General.OSE" /> application.</p>
         </div>
         <div>
             <h6>Configuration</h6>
-            <p>The following code sample illustrates how you can use the Proxy Protocol in your <MadCap:variable name="General.OSE" /> configuration (using the <span class="Code">transport()</span> parameter set to <span class="Code">proxied-tls</span>).</p><pre>@version: 3.30
+            <p>The following code sample illustrates how you can use the Proxy Protocol in your <MadCap:variable name="General.OSE" /> configuration (using the <span class="Code">transport()</span> parameter set to <span class="Code">proxied-tls-passthrough</span>).</p><pre>@version: 3.35
 
 source s_tcp_pp {
   network (
     port(6666)
-    transport("proxied-tls")
+    transport("proxied-tls-passthrough")
     tls(
         key-file("/certs/certs/server/server.rsa")
         cert-file("/certs/certs/server/server.crt")

--- a/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-conf.htm
+++ b/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-conf.htm
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+    <head>
+        <meta name="description" content="" />
+    </head>
+    <body name="proxy-prot-conf">
+        <h1 name="proxy-prot-conf">Proxy Protocol: configuration and output examples</h1>
+        <p>This section provides information about enabling Proxy Protocol support in your <span class="Code">network()</span> source options, and an example configuration and output to illustrate how  the Proxy Protocol method works  in <MadCap:variable name="General.product" /> (<MadCap:variable name="General.OSE" />).</p>
+        <p>For more information about the working mechanism of the Proxy Protocol, see <MadCap:xref href="proxy-prot-w-mech.htm"><span style="color: #04aada;" class="mcFormatColor">The working mechanism behind the Proxy Protocol</span></MadCap:xref>.</p>
+        <div>
+            <h6>Enabling Proxy Protocol support for your network() source options</h6>
+            <p>Unless you enable Proxy Protocol support for your <span class="Code">network()</span> source, <MadCap:variable name="General.OSE" /> identifies every connection that is connected to the load balancers identically by default, regardless of the source IP or the source protocol.</p>
+            <p class="Procedure">To enable Proxy Protocol for your <span class="Code">network()</span> source, set <a href="reference-source-network.htm"><span style="color: #04aada;" class="mcFormatColor">the <span class="Code">transport()</span> parameter of your <span class="Code">network()</span> source</span></a> to <span class="Code">proxied-tcp</span> or <span class="Code">proxied-tls</span>, depending on your preference and configuration.</p>
+            <p>When you enable Proxy Protocol support  for your <span class="Code">network()</span> source, you can use the following configuration example with your <MadCap:variable name="General.OSE" /> application.</p>
+        </div>
+        <div>
+            <h6>Configuration</h6>
+            <p>The following code sample illustrates how you can use the Proxy Protocol in your <MadCap:variable name="General.OSE" /> configuration (using the <span class="Code">transport()</span> parameter set to <span class="Code">proxied-tls</span>).</p><pre>@version: 3.30
+
+source s_tcp_pp {
+  network (
+    port(6666)
+    transport("proxied-tls")
+    tls(
+        key-file("/certs/certs/server/server.rsa")
+        cert-file("/certs/certs/server/server.crt")
+        ca-dir("/certs/certs/CA")
+        peer-verify("required-trusted")
+    )
+  );
+};
+
+destination d_file {
+  file("/var/log/proxy-proto.log" template("$(format-json --scope nv-pairs)\n"));
+};
+
+log {
+  source(s_tcp_pp);
+  destination(d_file);
+};
+</pre>
+            <p>With this configuration, the Proxy Protocol method will perform injecting the information of the original connection into the forwarded TCP session, based on the working mechanism described in <MadCap:xref href="proxy-prot-w-mech.htm"><span style="color: #04aada;" class="mcFormatColor">The working mechanism behind the Proxy Protocol</span></MadCap:xref>.</p>
+            <p>The following example illustrates how the parsed macros will appear in the output.</p>
+            <div class="Example">
+                <h6>Example: Output for the PROXY TCP4 192.168.1.1 10.10.0.1 1111 2222 input header</h6>
+                <p>With the <span class="Code">PROXY TCP4 192.168.1.1 10.10.0.1 1111 2222</span> input header, the output looks like this:</p><pre>{"SOURCE":"s_tcp_pp","PROXIED_SRCPORT":"1111","PROXIED_SRCIP":"192.168.1.1","PROXIED_IP_VERSION":"4","PROXIED_DSTPORT":"2222","PROXIED_DSTIP":"10.10.0.1","PROGRAM":"TestMsg","MESSAGE":"","LEGACY_MSGHDR":"TestMsg","HOST_FROM":"localhost","HOST":"localhost"}
+</pre>
+                <p>Note that the <a href="proxy-prot-w-mech.htm#proxy-prot-adds-macros"><span style="color: #04aada;" class="mcFormatColor">macros</span></a> that <MadCap:variable name="General.OSE" /> adds to the message appear in the output.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-intro.htm
+++ b/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-intro.htm
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+    <head>
+        <meta name="description" content="" />
+    </head>
+    <body name="proxy-prot-intro">
+        <h1 name="proxy-prot-intro">Proxy Protocol support</h1>
+        <p>If you connect load balancers to your <MadCap:variable name="General.OSE" /> application, <MadCap:variable name="General.OSE" /> identifies every connection that is connected to the load balancers identically by default, regardless of the source IP or the source protocol. Essentially, the load balancer masks the source IP unless you enable <a href="https://www.haproxy.com/blog/haproxy/proxy-protocol/">Proxy Protocol</a> support for your proxy TLS <span class="Code">transport()</span> to inject information about the original connection into the forwarded TCP session.</p>
+        <p>For further details about the working mechanism behind the Proxy Protocol support on <MadCap:variable name="General.OSE" /> and the configuration details, see the following sections:</p>
+        <MadCap:snippetBlock src="../../../Resources/Snippets/Common/Part_Chapter_MiniTOC_DoNotEdit.flsnp" />
+    </body>
+</html>

--- a/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-w-mech.htm
+++ b/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-w-mech.htm
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+    <head>
+        <meta name="description" content="" />
+    </head>
+    <body name="proxy-prot-w-mech">
+        <h1 name="proxy-prot-w-mech">The working mechanism behind the Proxy Protocol</h1>
+        <p>This section describes how <MadCap:variable name="General.product" /> (<MadCap:variable name="General.OSE" />) supports the <a href="https://www.haproxy.com/blog/haproxy/proxy-protocol/">Proxy Protocol</a>. </p>
+        <div>
+            <h6>The working mechanism behind the Proxy Protocol</h6>
+            <p>When using the Proxy Protocol during load balancing, <MadCap:variable name="General.OSE" /> detects the information behind connections connected to the load balancer, then parses the injected information and adds the following macros to every message the comes through the connection later on:</p>
+            <a name="proxy-prot-adds-macros"></a>
+
+            <ul>
+                <li>
+                    <p><span class="Code">PROXY_SRCIP</span> (the source IP of the proxy)</p>
+                </li>
+                <li>
+                    <p><span class="Code">PROXY_SRCPORT</span> (the source port of the proxy)</p>
+                </li>
+                <li>
+                    <p><span class="Code">PROXY_DSTIP</span> (the destination IP of the proxy)</p>
+                </li>
+                <li>
+                    <p><span class="Code">PROXY_DSTPORT</span> (the destination port of the proxy)</p>
+                </li>
+            </ul>
+            <div class="Note">
+                <p class="Hyphenation"><span class="AllNoteStyles">NOTE:</span> Consider the following about macros and headers:</p>
+                    <ul>
+                        <li>
+                            <p>When the proxy protocol header is <span class="Code">PROXY UNKNOWN</span>, no additional macros are added.</p>
+                        </li>
+                        <li>
+                            <p>When <MadCap:variable name="General.OSE" /> cannot parse a proxy protocol header, the connection is closed:</p>
+                            <pre>[2020-11-20T17:33:22.189458] PROXY protocol header received; line='PROXYdsfj'
+[2020-11-20T17:33:22.189475] Error parsing PROXY protocol header;
+[2020-11-20T17:33:22.189517] Syslog connection closed; fd='13', client='AF_INET(127.0.0.1:51665)', local='AF_INET(0.0.0.0:6666)'
+[2020-11-20T17:33:22.189546] Freeing PROXY protocol source driver; driver='0x7fffcba5bcf0'
+[2020-11-20T17:33:22.189600] Closing log transport fd; fd='13'
+</pre>
+
+                        </li>
+                    </ul>
+            </div>
+            <div class="Note">
+                <p class="Hyphenation"><span class="AllNoteStyles">NOTE:</span> Since the driver only implements version 1 of the protocol, it only supports TCP4 and TCP6 connections. TLS connections also supported.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/Project/TOCs/syslog-ng-ose-guide-admin.fltoc
+++ b/Project/TOCs/syslog-ng-ose-guide-admin.fltoc
@@ -364,6 +364,16 @@
       <TocEntry
         Link="/Content/Guides/syslog-ng-guide-admin/chapters/reference-source-network.htm"
         Title="[%=System.LinkedTitle%]"></TocEntry>
+      <TocEntry
+        Title="[%=System.LinkedTitle%]"
+        Link="/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-intro.htm" xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+        <TocEntry
+          Title="[%=System.LinkedTitle%]"
+          Link="/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-w-mech.htm" xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd" />
+        <TocEntry
+          Title="[%=System.LinkedTitle%]"
+          Link="/Content/Guides/syslog-ng-guide-admin/chapters/proxy-prot-conf.htm" xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd" />
+      </TocEntry>
     </TocEntry>
     <TocEntry
       Link="/Content/Guides/syslog-ng-guide-admin/chapters/configuring-source-nodejs.htm"


### PR DESCRIPTION
Note: I did not add an entry to `Content/Guides/syslog-ng-guide-admin/chapters/soc.htm`.

The proxy protocol support itself was introduced in syslog-ng OSE v3.30.
The proxied-tls-passthrough is newer: v3.35.