### PR TITLE
ose 3.37 ag DOC-3887 fixing missing snippet issue, mariadb-audit parser

### DIFF
--- a/Content/Guides/syslog-ng-guide-admin/parser-mariadb-audit.htm
+++ b/Content/Guides/syslog-ng-guide-admin/parser-mariadb-audit.htm
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
     <head>
         <link href="../../Resources/TableStyles/RuledTableWithHeading_DoNotEdit.css" rel="stylesheet" MadCap:stylesheetType="table" />
@@ -25,9 +25,9 @@ log {
         </div>
         <p>The <span class="Code">mariadb-audit</span> is a reusable configuration snippet configured to parse MariaDB Audit Plugin messages. For details on using or writing such configuration snippets, see <MadCap:xref href="config-blocks.htm"><span style="color: #04aada;" class="mcFormatColor">Reusing configuration blocks</span></MadCap:xref>. You can find the source of this configuration snippet on <a href="https://github.com/syslog-ng/syslog-ng/blob/master/scl/mariadb/audit.conf">GitHub</a>.</p>
         <div>
-            <MadCap:snippetBlock src="../shared/chunk/option-parser-prefix.htm">
+            <MadCap:snippetBlock src="../shared/chunk/option-parser-prefix.flsnp">
             </MadCap:snippetBlock>
-            <MadCap:snippetBlock src="../shared/chunk/para-macro-prefix-parser.htm">
+            <MadCap:snippetBlock src="../shared/chunk/para-macro-prefix-parser.flsnp">
             </MadCap:snippetBlock>
             <p>By default, <span class="Code">mariadb-audit</span> uses the <span class="Code">.mariadb.</span> prefix. To modify it, use the following format:</p><pre>parser {
     mariadb-audit-parser(prefix("myprefix."));


### PR DESCRIPTION
Changing the .htm to .flsnp in the links in the parser-mariadb-audit.htm file