### PR TITLE
syslog-ng OSE 3.38 documentation: JSON updates and link fixes

### DIFF
--- a/Content/Guides/shared/documentation-license.htm
+++ b/Content/Guides/shared/documentation-license.htm
@@ -3,7 +3,7 @@
     <head>
     </head>
     <body name="documentation-license">
-        <h1 name="documentation-license">The <MadCap:variable name="CommonVariables.OSELong" /> Documentation License</h1>
+        <h1 name="documentation-license">The <MadCap:variable name="General.OSELong" /> Documentation License</h1>
         <MadCap:snippetBlock src="../../Resources/Snippets/Common/Legal/CopyrightTitle.flsnp" />
         <p>Permission is hereby granted, free of charge, to any person obtaining a copy of these documentation files (the "Documentation"), to use the Documentation subject to the following conditions:</p>
         <ol>

--- a/Content/Guides/syslog-ng-guide-admin/concepts-licensing.htm
+++ b/Content/Guides/syslog-ng-guide-admin/concepts-licensing.htm
@@ -11,6 +11,6 @@
 			Practically, the code stored under the <span class="Code">lib</span> directory of the source code package is under LGPL, the rest is GPL.</p>
         </div>
         <p>For details about the LGPL and GPL licenses, see <MadCap:xref href="../shared/lgpl-2.1.htm"><span style="color: #04aada;" class="mcFormatColor">GNU Lesser General Public License</span></MadCap:xref> and <MadCap:xref href="../shared/gpl.htm"><span style="color: #04aada;" class="mcFormatColor">GNU General Public License</span></MadCap:xref>, respectively.</p>
-        <p>For clarity, the Documentation is licensed separately. For details, see <MadCap:xref href="../shared/documentation-license.htm"><span style="color: #04aada;" class="mcFormatColor">The <MadCap:variable name="CommonVariables.OSELong" /> Documentation License</span></MadCap:xref>.</p>
+        <p>For clarity, the Documentation is licensed separately. For details, see <MadCap:xref href="../shared/documentation-license.htm"><span style="color: #04aada;" class="mcFormatColor">The <MadCap:variable name="General.OSELong" /> Documentation License</span></MadCap:xref>.</p>
     </body>
 </html>

--- a/Content/Guides/syslog-ng-guide-admin/what-syslog-ng-is.htm
+++ b/Content/Guides/syslog-ng-guide-admin/what-syslog-ng-is.htm
@@ -9,7 +9,7 @@
         <p>Among others, <MadCap:variable name="General.abbrev" /> allows you the following.</p>
         <div>
             <h6>Secure and reliable log transfer</h6>
-            <p>The <MadCap:variable name="General.abbrev"></MadCap:variable> application enables you to send the log messages of your hosts to remote servers using the latest protocol standards. You can collect and store your log data centrally on dedicated log servers. Transfer log messages using the <MadCap:conditionaltext MadCap:conditions="General.PE"><MadCap:variable name="syslogngPEVariables.RLTPUppercase" /></MadCap:conditionaltext><MadCap:conditionaltext MadCap:conditions="General.OSE">TCP</MadCap:conditionaltext> protocol ensures that no messages are lost.</p>
+            <p>The <MadCap:variable name="General.abbrev" /> application enables you to send the log messages of your hosts to remote servers using the latest protocol standards. You can collect and store your log data centrally on dedicated log servers. Transfer log messages using the <MadCap:conditionaltext MadCap:conditions="General.OSE">TCP</MadCap:conditionaltext> protocol ensures that no messages are lost.</p>
         </div>
         <div>
             <h6>Disk-based message buffering</h6>
@@ -45,9 +45,9 @@
             <p>Storing your log messages in a database allows you to easily search and query the messages and interoperate with log analyzing applications. The syslog-ng application supports the following databases: MongoDB, MSSQL, MySQL, Oracle, PostgreSQL, and SQLite.</p>
             <p><MadCap:variable name="General.abbrev"></MadCap:variable> also allows you to extract the information you need from your log data, and directly send it to your Graphite, Redis, or Riemann monitoring system.</p>
         </div>
-		<div>
-        <h6>Wide protocol and platform support</h6>
-		</div>
+        <div>
+            <h6>Wide protocol and platform support</h6>
+        </div>
         <div>
             <h6>syslog protocol standards</h6>
             <p>syslog-ng not only supports legacy BSD syslog (RFC3164) and the enhanced RFC5424 protocols but also JavaScript Object Notation (JSON) and journald message formats.</p>

--- a/Content/Guides/whatsnew/4. Enhancements.htm
+++ b/Content/Guides/whatsnew/4. Enhancements.htm
@@ -10,7 +10,7 @@
         <p>The following is a list of enhancements implemented in <MadCap:variable name="CommonVariables.ProductNameShort" /> <MadCap:variable name="CommonVariables.Version" />.</p>
         <p><b>Documentation license update</b>
         </p>
-        <p>Added the <MadCap:variable name="General.product" /> documentation license to the product documentation. For more information, see <MadCap:xref href="../shared/documentation-license.htm"><span style="color: #04aada;" class="mcFormatColor"><MadCap:variable name="CommonVariables.OSELong" /> documentation license</span></MadCap:xref>.</p>
+        <p>Added the <MadCap:variable name="General.product" /> documentation license to the product documentation. For more information, see <MadCap:xref href="../shared/documentation-license.htm"><span style="color: #04aada;" class="mcFormatColor"><MadCap:variable name="General.OSELong" /> documentation license</span></MadCap:xref>.</p>
         <table style="width: 100%;mc-table-style: url('../../Resources/TableStyles/RuledTableWithHeading_DoNotEdit.css');margin-left: 0;margin-right: auto;" class="TableStyle-RuledTableWithHeading_DoNotEdit" cellspacing="0" MadCap:conditions="CommonConditions_DoNotEdit.DoNotPublish">
             <caption MadCap:autonum="Table 1: ">General enhancements</caption>
             <col class="TableStyle-RuledTableWithHeading_DoNotEdit-Column-Column1" />

--- a/Maketargets.json
+++ b/Maketargets.json
@@ -1,6 +1,6 @@
 {
     "global": {
-        "product": "syslog-ng Open Source Edition 3.36",
+        "product": "syslog-ng Open Source Edition 3.38",
         "productnamelong": "syslog-ng Open Source Edition",
         "productnameshort": "syslog-ng OSE",
         "productnameinepic": "syslog-ng-open-source-edition",
@@ -8,11 +8,12 @@
         "conditions-to-exclude": "General.PE or General.pe6 or General.SPS or General.SRA or General.ARS",
         "version": "3.38",
         "techversion": "3.38"
+		"onlinedocumentation": "https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition"
     },
     "syslog-ng-ose-guide-admin": {
         "condition": "General.OSE",
         "doc_id": "syslog-ng-ose-guide-admin",
-        "doc_setname": "syslog-ng-ose-3.36-guides",
+        "doc_setname": "syslog-ng-ose-3.38-guides",
         "title": "Administration Guide",
         "type": "Administration Guide",
         "description": "This manual is the primary documentation of the syslog-ng Open Source Edition application"
@@ -20,7 +21,7 @@
    "syslog-ng-ose-guide-whatsnew": {
         "condition": "General.OSE",
         "doc_id": "syslog-ng-ose-guide-whatsnew",
-        "doc_setname": "syslog-ng-ose-3.36-guides",
+        "doc_setname": "syslog-ng-ose-3.38-guides",
         "title": "Release Notes",
         "type": "Release Notes",
         "description": "Describes the new features and other highlights of this release of the syslog-ng Open Source Edition application"
@@ -28,7 +29,7 @@
     "syslog-ng-tutorial-mutual-auth-tls": {
         "condition": "General.OSE",
         "doc_id": "syslog-ng-tutorial-mutual-auth-tls",
-        "doc_setname": "syslog-ng-ose-3.36-guides",
+        "doc_setname": "syslog-ng-ose-3.38-guides",
         "title": "Mutual authentication using TLS",
         "type": "Best Practices",
         "description": "This tutorial shows you step-by-step how to create the certificates required to authenticate your server and your clients, and how to configure syslog-ng Open Source Edition (syslog-ng OSE) to send your log messages in an encrypted connection"


### PR DESCRIPTION
- Updated configuration JSON with some version number fixes and online documentation link used for documentation output target generation.
- Fixed a handful of broken variable references.